### PR TITLE
Update build option for introspection

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,22 @@
+«»
+
+  Features
+
+   - ~
+
+  Refactoring
+
+   - ~
+
+  Bug fixes
+
+   - ~
+
+  Build changes
+
+   - Update build option for introspection. This is now a feature that must be
+     enabled instead of just a boolean. See <https://github.com/ebassi/graphene/pull/200>.
+
 0.001 2020-10-17 00:51:37-0500
 
   Features

--- a/alienfile
+++ b/alienfile
@@ -23,7 +23,7 @@ share {
 			'--prefix=%{.install.prefix}',
 			'--libdir=lib',
 			'--buildtype=release',
-			'-Dintrospection=true',
+			'-Dintrospection=enabled',
 			'-Dgobject_types=true',
 			$build_dir ],
 		[ @ninja_run, qw(-C), $build_dir, "test" ],


### PR DESCRIPTION
This is now a feature that must be enabled instead of just a boolean.
See <https://github.com/ebassi/graphene/pull/200>.